### PR TITLE
Updated CHANGELOG.md release data, because somehow a pre-release version got tagged as 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2023-10-17
+## [1.0.0] - 2023-12-08
 
 ### Changes in version 1.0.0
 


### PR DESCRIPTION
Fix initial release 1.0 version date.